### PR TITLE
Added comptime .env parsing

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-password= mysecretpassword
-somekey  = "somekey" 
-number=123
-keywith2spaces= 'keywith2spaces  '

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 0. with zon: zig fetch --save "thisrepo/hash"
    in build.zig, add the module (the name of the module is "dotenv")
 
-2. Create a `.env` file in your project or executable directory:
+1. Create a `.env` file in your project or executable directory:
 
    ```sh
    # .env
@@ -18,7 +18,7 @@
    ANOTHER_VAR=world
    ```
 
-3. Use dotenv to read the environment variable:
+2. Use dotenv to read the environment variable:
 
    ```zig
    const Env = @import("dotenv");
@@ -35,6 +35,18 @@
       std.debug.print("{s}\n", .{env.get("password").?});
       // Use the environment variables
       // ...
+   }
+   ```
+
+3. Use dotenv to get a key from a dotenv file at comptime:
+
+   ```zig
+   const Env = @import("dotenv");
+   pub fn main() !void {
+      const content = @embedFile(".env");
+      try expect(try Env.parse_key("no key", content) == null);
+      const password = try Env.parse_key("password", content);
+      try expect(std.mem.eql(u8, password.?, "mysecretpassword"));
    }
    ```
 


### PR DESCRIPTION
the original approach was to read all key values into a hashmap needing an allocator.
i found this a problem as i needed a key value at comptime from the dotenv file.
therefore i added a simple function only for this usecase, usage is described in the readme.md.


