### PR TITLE
feat: add process environment variable support for cloud deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.zig-cache/
+zig-cache/
+zig-out/
+.git/
+.gitignore
+*.md
+LICENSE
+licenses.txt
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# ============================================================
+# Stage 1: Builder
+# ============================================================
+FROM debian:bookworm-slim AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    xz-utils \
+    ca-certificates \
+    libssl-dev \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Install Zig
+ARG ZIG_VERSION=0.15.1
+RUN curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" | tar -xJ -C /usr/local && \
+    ln -s "/usr/local/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files first (for better caching)
+COPY build.zig build.zig.zon ./
+
+# Copy source code
+COPY src ./src
+
+# Copy the built binary from builder stage
+CMD ["zig", "build", "test"]
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - values in double or single quotes get stripped: "myvalue" -> myvalue
 - does not check keys for syntax correctness
 - dupes the key-values into a hashmap, so the input buffer may get deallocated without problems
+- **Process environment variable support** - automatically falls back to process environment when key is not found in .env file
 - No dependencies
 
 ## Usage
@@ -27,7 +28,7 @@
    ```zig
    const Env = @import("dotenv");
    pub fn main() !void {
-      const alloc = std.testing.allocator;
+      const alloc = std.heap.page_allocator;
       // read the env file
       var file = try std.fs.cwd().openFile(".env", .{});
       defer file.close();
@@ -36,6 +37,24 @@
       // parse the env file
       var env: Env = try Env.init(alloc, content);
       defer env.deinit();
+      // This will first check the .env file, then fall back to process environment if not found
+      std.debug.print("{s}\n", .{env.get("password").?});
+      // Use the environment variables
+      // ...
+   }
+   ```
+
+   Alternatively, use `init_with_path` for a more convenient approach:
+
+   ```zig
+   const Env = @import("dotenv");
+   pub fn main() !void {
+      const alloc = std.heap.page_allocator;
+      // init_with_path handles file opening, reading, and cleanup automatically
+      // Set use_process_env=true to fall back to process environment if .env file is not found
+      var env: Env = try Env.init_with_path(alloc, ".env", 1024 * 1024, true);
+      defer env.deinit();
+      // This will first check the .env file, then fall back to process environment if not found
       std.debug.print("{s}\n", .{env.get("password").?});
       // Use the environment variables
       // ...
@@ -53,6 +72,63 @@
       try expect(std.mem.eql(u8, password.?, "mysecretpassword"));
    }
    ```
+
+4. Process environment variable support (for cloud deployments):
+
+   When a key is not found in the `.env` file, `Env.get()` automatically falls back to reading from the process environment. This makes it perfect for cloud deployments where environment variables are provided by the platform.
+
+   **Option A: Initialize without a .env file** (process environment only):
+
+   ```zig
+   const Env = @import("dotenv");
+   pub fn main() !void {
+      const alloc = std.heap.page_allocator;
+      // Initialize without a .env file - will use process environment only
+      var env: Env = try Env.init(alloc, null);
+      defer env.deinit();
+
+      // This will read from process environment (e.g., set by Docker, Heroku, AWS Lambda, etc.)
+      if (env.get("DATABASE_URL")) |url| {
+         std.debug.print("Database URL: {s}\n", .{url});
+      }
+   }
+   ```
+
+   **Option B: Use `init_with_path` with fallback** (recommended for cloud deployments):
+
+   ```zig
+   const Env = @import("dotenv");
+   pub fn main() !void {
+      const alloc = std.heap.page_allocator;
+      // If .env file exists, use it; otherwise fall back to process environment
+      // This works seamlessly in both local development and cloud deployments
+      var env: Env = try Env.init_with_path(alloc, ".env", 1024 * 1024, true);
+      defer env.deinit();
+
+      // This will check .env file first, then process environment
+      if (env.get("DATABASE_URL")) |url| {
+         std.debug.print("Database URL: {s}\n", .{url});
+      }
+   }
+   ```
+
+   This is particularly useful for:
+
+   - Cloud platforms (Heroku, AWS Lambda, Google Cloud Run, etc.)
+   - Docker containers with environment variables
+   - CI/CD pipelines
+   - Production environments where .env files should not be included
+   - Local development where you want .env file support with cloud deployment compatibility
+
+## Docker Testing
+
+The repository includes Docker support for testing process environment functionality:
+
+```bash
+docker-compose up --build
+```
+
+This will run all tests with environment variables set via Docker Compose, verifying that process environment variable support works correctly.
 
 ## Contributing
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .dotenv,
     .fingerprint = 0xd19ca053c87c4032,
     .version = "0.1.1",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - password=mysecretpassword
+      - number=123
+      - somekey=somekey-
+      # Note: Trailing spaces in keywith2spaces need to be preserved
+      # Using quotes to preserve trailing spaces
+      - 'keywith2spaces=keywith2spaces  '
+    # Override CMD to run specific test if needed
+    # command: zig build test --test-filter "test process env"
+

--- a/src/root.zig
+++ b/src/root.zig
@@ -131,7 +131,7 @@ test "test" {
     try expect(std.mem.eql(u8, env.get("number").?, "123"));
     try expect(std.mem.eql(u8, env.get("somekey").?, "somekey"));
     try expect(std.mem.eql(u8, env.get("keywith2spaces").?, "keywith2spaces  "));
-    // std.debug.print("{s}\n", .{env.get("password").?});
+    std.debug.print("done with test\n", .{});
 }
 
 test "test comptime" {
@@ -140,6 +140,7 @@ test "test comptime" {
     try expect(try Env.parse_key("no key", content) == null);
     const password = try Env.parse_key("password", content);
     try expect(std.mem.eql(u8, password.?, "mysecretpassword"));
+    std.debug.print("done with comptime test\n", .{});
 }
 
 test "test init_with_path" {
@@ -151,7 +152,7 @@ test "test init_with_path" {
     try expect(std.mem.eql(u8, env.get("number").?, "123"));
     try expect(std.mem.eql(u8, env.get("somekey").?, "somekey"));
     try expect(std.mem.eql(u8, env.get("keywith2spaces").?, "keywith2spaces  "));
-    // std.debug.print("{s}\n", .{env.get("password").?});
+    std.debug.print("done with init_with_path test\n", .{});
 }
 
 test "test process env" {
@@ -164,5 +165,5 @@ test "test process env" {
     try expect(std.mem.eql(u8, env.get("number").?, "123"));
     try expect(std.mem.eql(u8, env.get("somekey").?, "somekey-"));
     try expect(std.mem.eql(u8, env.get("keywith2spaces").?, "keywith2spaces  "));
-    // std.debug.print("{s}\n", .{env.get("password").?});
+    std.debug.print("done with process env test\n", .{});
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -152,7 +152,7 @@ test "test comptime" {
 
 test "test init_with_path" {
     const alloc = std.testing.allocator;
-    var env: Env = try Env.init_with_path(alloc, "src/.env", 1024 * 1024, true);
+    var env: Env = try Env.initWithPath(alloc, "src/.env", 1024 * 1024, true);
     defer env.deinit();
     try expect(env.get("no key") == null);
     try expect(std.mem.eql(u8, env.get("password").?, "mysecretpassword"));

--- a/src/root.zig
+++ b/src/root.zig
@@ -86,7 +86,7 @@ pub fn init(alloc: Allocator, file_content: ?[]const u8) !Env {
     return env;
 }
 
-pub fn init_with_path(alloc: Allocator, path: []const u8, max_bytes: usize, use_process_env: bool) !Env {
+pub fn initWithPath(alloc: Allocator, path: []const u8, max_bytes: usize, use_process_env: bool) !Env {
     var file = std.fs.cwd().openFile(path, .{}) catch |err| {
         if (use_process_env and err == error.FileNotFound) {
             return try init(alloc, null);
@@ -116,6 +116,13 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     const proc_val = std.posix.getenv(key) orelse return null;
 
     return proc_val;
+}
+
+pub fn getRequired(self: *Env, key: []const u8) ![]const u8 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return val;
 }
 
 test "test" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -125,6 +125,138 @@ pub fn getRequired(self: *Env, key: []const u8) ![]const u8 {
     return val;
 }
 
+pub fn getWithDefault(self: *Env, key: []const u8, default: []const u8) []const u8 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return val;
+}
+
+pub fn parseU16(self: *Env, key: []const u8) !u16 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseInt(u16, val, 10) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseU16WithDefault(self: *Env, key: []const u8, default: u16) u16 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseInt(u16, val, 10) catch {
+        return default;
+    };
+}
+
+pub fn parseU32(self: *Env, key: []const u8) !u32 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseInt(u32, val, 10) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseU32WithDefault(self: *Env, key: []const u8, default: u32) u32 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseInt(u32, val, 10) catch {
+        return default;
+    };
+}
+
+pub fn parseU64(self: *Env, key: []const u8) !u64 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseInt(u64, val, 10) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseU64WithDefault(self: *Env, key: []const u8, default: u64) u64 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseInt(u64, val, 10) catch {
+        return default;
+    };
+}
+
+pub fn parseUsize(self: *Env, key: []const u8) !usize {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseInt(usize, val, 10) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseUsizeWithDefault(self: *Env, key: []const u8, default: usize) usize {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseInt(usize, val, 10) catch {
+        return default;
+    };
+}
+
+pub fn parseBool(self: *Env, key: []const u8) !bool {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseBool(val) catch {
+        return error.InvalidEnvVar;
+    };
+}
+pub fn parseBoolWithDefault(self: *Env, key: []const u8, default: bool) bool {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseBool(val) catch {
+        return default;
+    };
+}
+
+pub fn parseFloat(self: *Env, key: []const u8) !f32 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseFloat(f32, val) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseFloatWithDefault(self: *Env, key: []const u8, default: f32) f32 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseFloat(f32, val) catch {
+        return default;
+    };
+}
+
+pub fn parseDouble(self: *Env, key: []const u8) !f64 {
+    const val = self.get(key) orelse {
+        return error.MissingRequiredEnvVar;
+    };
+    return std.fmt.parseFloat(f64, val) catch {
+        return error.InvalidEnvVar;
+    };
+}
+
+pub fn parseDoubleWithDefault(self: *Env, key: []const u8, default: f64) f64 {
+    const val = self.get(key) orelse {
+        return default;
+    };
+    return std.fmt.parseFloat(f64, val) catch {
+        return default;
+    };
+}
+
 test "test" {
     const alloc = std.testing.allocator;
     var file = try std.fs.cwd().openFile("src/.env", .{});
@@ -173,4 +305,25 @@ test "test process env" {
     try expect(std.mem.eql(u8, env.get("somekey").?, "somekey-"));
     try expect(std.mem.eql(u8, env.get("keywith2spaces").?, "keywith2spaces  "));
     std.debug.print("done with process env test\n", .{});
+}
+
+test "test parseU16, U32, U64, Usize, Bool, Float, Double" {
+    const alloc = std.testing.allocator;
+    var env: Env = try Env.initWithPath(alloc, "src/.env", 1024 * 1024, true);
+    defer env.deinit();
+    try expect(env.parseU16("u16") == 123);
+    try expect(env.parseU16WithDefault("u16", 456) == 123);
+    try expect(env.parseU32("u32") == 123);
+    try expect(env.parseU32WithDefault("u32", 456) == 123);
+    try expect(env.parseU64("u64") == 123);
+    try expect(env.parseU64WithDefault("u64", 456) == 123);
+    try expect(env.parseUsize("usize") == 123);
+    try expect(env.parseUsizeWithDefault("usize", 456) == 123);
+    try expect(env.parseBool("bool") == true);
+    try expect(env.parseBoolWithDefault("bool", false) == true);
+    try expect(env.parseFloat("float") == 123.0);
+    try expect(env.parseFloatWithDefault("float", 456.0) == 123.0);
+    try expect(env.parseDouble("double") == 123.0);
+    try expect(env.parseDoubleWithDefault("double", 456.0) == 123.0);
+    std.debug.print("done with parseU16, U32, U64, Usize, Bool, Float, Double test\n", .{});
 }


### PR DESCRIPTION
feat: add process environment variable support for cloud deployments

Add support for reading environment variables from the process environment
when no .env file is present. This enables the library to work seamlessly
in cloud-based environments where environment variables are provided by the
platform (e.g., Heroku, AWS Lambda, Google Cloud Run, Docker containers)
without requiring a .env file to be included in the deployment.

## Changes

- `Env.get()` now falls back to `std.posix.getenv()` when a key is not found
  in the parsed .env file cache
- Added Docker testing infrastructure to verify process.env functionality
- Added Dockerfile and docker-compose.yml for testing in containerized environments

## Use Case

This feature is particularly useful for:

- Cloud platforms that inject environment variables at runtime
- Containerized deployments where env vars are set via orchestration tools
- CI/CD pipelines that prefer environment variables over file-based config
- Production environments where .env files should not be included in deployments

## Testing

Run the process environment test using Docker:

```bash
docker-compose up --build
```
