### PR TITLE
This pull request adds windows compactibily and improves the handling of boolean environment variables

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -123,13 +123,14 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
 
     // Cache for future lookups using the arena allocator
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
-        _ = self.vars.put(dup_key, proc_val) catch |put_err| {
+        self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
             self.arena.allocator().free(dup_key);
             self.arena.allocator().free(proc_val);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });
+        self.arena.allocator().free(proc_val);
     }
 
     return proc_val;

--- a/src/root.zig
+++ b/src/root.zig
@@ -125,6 +125,7 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
         _ = self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
+            self.arena.allocator().free(dup_key);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });

--- a/src/root.zig
+++ b/src/root.zig
@@ -113,7 +113,10 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     }
 
     // Get from process environment
-    const proc_val = std.posix.getenv(key) orelse return null;
+    const proc_val = std.process.getEnvVarOwned(self.arena.allocator(), key) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return null,
+        else => return null,
+    };
 
     return proc_val;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -126,9 +126,11 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
         self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
             self.arena.allocator().free(dup_key);
+            self.arena.allocator().free(proc_val);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });
+        self.arena.allocator().free(proc_val);
     }
 
     return proc_val;

--- a/src/root.zig
+++ b/src/root.zig
@@ -208,17 +208,26 @@ pub fn parseBool(self: *Env, key: []const u8) !bool {
     const val = self.get(key) orelse {
         return error.MissingRequiredEnvVar;
     };
-    return std.fmt.parseBool(val) catch {
+    // Accept common bool env var values: "true"/"1", "false"/"0" (case-insensitive)
+    if (std.ascii.eqlIgnoreCase(val, "true") or std.ascii.eqlIgnoreCase(val, "1")) {
+        return true;
+    } else if (std.ascii.eqlIgnoreCase(val, "false") or std.ascii.eqlIgnoreCase(val, "0")) {
+        return false;
+    } else {
         return error.InvalidEnvVar;
-    };
+    }
 }
 pub fn parseBoolWithDefault(self: *Env, key: []const u8, default: bool) bool {
     const val = self.get(key) orelse {
         return default;
     };
-    return std.fmt.parseBool(val) catch {
+    if (std.ascii.eqlIgnoreCase(val, "true") or std.ascii.eqlIgnoreCase(val, "1")) {
+        return true;
+    } else if (std.ascii.eqlIgnoreCase(val, "false") or std.ascii.eqlIgnoreCase(val, "0")) {
+        return false;
+    } else {
         return default;
-    };
+    }
 }
 
 pub fn parseFloat(self: *Env, key: []const u8) !f32 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -126,6 +126,7 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
         _ = self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
             self.arena.allocator().free(dup_key);
+            self.arena.allocator().free(proc_val);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });

--- a/src/root.zig
+++ b/src/root.zig
@@ -125,6 +125,7 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
         self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
+            self.arena.allocator().free(dup_key);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });

--- a/src/root.zig
+++ b/src/root.zig
@@ -123,9 +123,10 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
 
     // Cache for future lookups using the arena allocator
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
-        if (self.vars.put(dup_key, proc_val)) |_| {} else |put_err| {
+        _ = self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
-        }
+            self.arena.allocator().free(dup_key) catch {};
+        };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });
     }

--- a/src/root.zig
+++ b/src/root.zig
@@ -125,7 +125,6 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
         _ = self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
-            self.arena.allocator().free(dup_key) catch {};
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });

--- a/src/root.zig
+++ b/src/root.zig
@@ -125,12 +125,9 @@ pub fn get(self: *Env, key: []const u8) ?[]const u8 {
     if (self.arena.allocator().dupe(u8, key)) |dup_key| {
         self.vars.put(dup_key, proc_val) catch |put_err| {
             std.log.err("failed to cache env var {s}: {s}", .{ key, @errorName(put_err) });
-            self.arena.allocator().free(dup_key);
-            self.arena.allocator().free(proc_val);
         };
     } else |alloc_err| {
         std.log.err("failed to cache env key {s}: {s}", .{ key, @errorName(alloc_err) });
-        self.arena.allocator().free(proc_val);
     }
 
     return proc_val;


### PR DESCRIPTION
This pull request improves the handling of boolean environment variables by making the parsing logic more flexible and user-friendly. The `parseBool` and `parseBoolWithDefault` functions now accept both `"true"/"1"` and `"false"/"0"` (case-insensitive) as valid boolean values, instead of relying solely on Zig's standard boolean parsing.

Improvements to environment variable parsing:

* Updated the `parseBool` and `parseBoolWithDefault` methods in `src/root.zig` to accept common boolean representations (`"true"`, `"1"`, `"false"`, `"0"`, case-insensitive) for environment variables, improving compatibility and robustness.